### PR TITLE
Preserve metadata during itk <-> sitk conversion

### DIFF
--- a/ormir_xct/core/util/sitk_itk.py
+++ b/ormir_xct/core/util/sitk_itk.py
@@ -35,6 +35,13 @@ def sitk_itk(sitk_image):
         itk.GetMatrixFromArray(np.reshape(np.array(sitk_image.GetDirection()), [3] * 2))
     )
 
+    metadata_dict = itk_image.GetMetaDataDictionary()
+    for key in sitk_image.GetMetaDataKeys():
+        try:
+            metadata_dict[key] = sitk_image.GetMetaData(key)
+        except (RuntimeError, TypeError):
+            pass
+
     return itk_image
 
 

--- a/ormir_xct/core/util/sitk_itk.py
+++ b/ormir_xct/core/util/sitk_itk.py
@@ -40,15 +40,7 @@ def sitk_itk(sitk_image):
 
 def itk_sitk(itk_image):
     """
-    Convert an ITK image to a SimpleITK image.
-
-    Parameters
-    ----------
-    itk_image : ITK.Image
-
-    Returns
-    -------
-    sitk_image : SimpleITK.Image
+    Convert an ITK image to a SimpleITK image, preserving metadata.
     """
     sitk_image = sitk.GetImageFromArray(
         itk.GetArrayFromImage(itk_image),
@@ -56,6 +48,18 @@ def itk_sitk(itk_image):
     )
     sitk_image.SetOrigin(tuple(itk_image.GetOrigin()))
     sitk_image.SetSpacing(tuple(itk_image.GetSpacing()))
-    sitk_image.SetDirection(itk.GetArrayFromMatrix(itk_image.GetDirection()).flatten())
+    sitk_image.SetDirection(
+        itk.GetArrayFromMatrix(itk_image.GetDirection()).flatten()
+        )
+
+    # Preserve scanner/header metadata
+    metadata_dict = itk_image.GetMetaDataDictionary()
+    for key in metadata_dict.GetKeys():
+        if key.startswith("ITK_"):
+            continue  # internal ITK keys, not scan metadata
+        try:
+            sitk_image.SetMetaData(key, str(metadata_dict[key]))
+        except (RuntimeError, TypeError):
+            pass  # skip if metadata cannot be converted to string
 
     return sitk_image

--- a/tests/util/test_itk_sitk_conversion.py
+++ b/tests/util/test_itk_sitk_conversion.py
@@ -72,15 +72,19 @@ class TestSITKToITKConversion(unittest.TestCase):
     def test_sitk_to_itk(self):
         expected_image = itk.GetImageFromArray(create_test_image((10, 10, 10), 1))
         test_image = sitk.GetImageFromArray(create_test_image((10, 10, 10), 1))
+        
+        test_metadata = {"PatientName": "TEST-PATIENT", "ScannerID": "1234"}
+        for key, value in test_metadata.items():
+            test_image.SetMetaData(key, value)
 
         result_image = sitk_itk(test_image)
 
-        epected_image_np = itk.GetArrayFromImage(expected_image)
+        expected_image_np = itk.GetArrayFromImage(expected_image)
         result_image_np = itk.GetArrayFromImage(result_image)
 
         np.testing.assert_array_equal(expected_image, result_image)
         self.spacing_check(expected_image, result_image)
-        self.dimension_check(epected_image_np, result_image_np)
+        self.dimension_check(expected_image_np, result_image_np)
         self.position_check(expected_image, result_image)
 
         expected_itk_direction = (
@@ -106,3 +110,35 @@ class TestSITKToITKConversion(unittest.TestCase):
             result_image.GetDirection()(2, 2),
         )
         self.direction_check(expected_itk_direction, result_itk_direction)
+        self.metadata_check(result_image, test_metadata)
+
+    def metadata_check(self, output_image, expected_metadata):
+        """
+        Checks that expected metadata is present in an ITK or SimpleITK image.
+        """
+        if isinstance(output_image, sitk.Image):
+            output_dict = {k: output_image.GetMetaData(k) for k in output_image.GetMetaDataKeys()}
+        else:
+            output_dict = dict(output_image)
+
+        for key, value in expected_metadata.items():
+            self.assertIn(key, output_dict)
+            self.assertEqual(str(output_dict[key]), str(value))
+
+    def test_itk_to_sitk_metadata(self):
+        test_image = itk.GetImageFromArray(create_test_image((10, 10, 10), 1))
+
+        test_metadata = {
+            "PatientName": "TEST-PATIENT",
+            "ScannerID": "1234",
+        }
+        metadata_dict = test_image.GetMetaDataDictionary()
+        for key, value in test_metadata.items():
+            metadata_dict[key] = value
+
+        result_image = itk_sitk(test_image)
+
+        result_keys = result_image.GetMetaDataKeys()
+        for key, value in test_metadata.items():
+            self.assertIn(key, result_keys)
+            self.assertEqual(result_image.GetMetaData(key), value)


### PR DESCRIPTION
Hi everyone,

To guarantee the further integration of ORMIR_XCT with ormir-mids, it would be beneficial to store the Scanco header in SimpleITK.MetaData().

Currently, the functions `sitk_itk(sitk_image)` and `itk_sitk(itk_image)` in `ormir_xct/core/util/sitk_itk.py` only store a limited amount of metadata (origin, spacing, direction), discarding the rest.

The aim of this pull request is to improve interoperability between SimpleITK and ITK image conversions by ensuring that header information provided by Scanco is preserved in the metadata during conversions in both directions. Unit tests are provided to verify that the metadata is transferred correctly during these conversions.

**Metadata preservation improvements:**
* Modified the `sitk_itk()` function to copy all metadata from the SimpleITK image to the ITK image's metadata dictionary.
```python
metadata_dict = itk_image.GetMetaDataDictionary()
for key in sitk_image.GetMetaDataKeys():
    try:
        metadata_dict[key] = sitk_image.GetMetaData(key)
    except (RuntimeError, TypeError):
        pass
```
* Updated the `itk_sitk()` function to transfer all non-internal metadata from the ITK image to the SimpleITK image.
```python
# Preserve scanner/header metadata
metadata_dict = itk_image.GetMetaDataDictionary()
for key in metadata_dict.GetKeys():
    if key.startswith("ITK_"):
        continue  # internal ITK keys, not scan metadata
    try:
        sitk_image.SetMetaData(key, str(metadata_dict[key]))
    except (RuntimeError, TypeError):
        pass  # skip if metadata cannot be converted to string
```

**Important:** this is still a draft. I recommend thoroughly testing the new adaptations when integrating the image reader into ormir-mids at the workshop.